### PR TITLE
CssSelect: update docs (asArray -> asDomList)

### DIFF
--- a/src/CssSelect.php
+++ b/src/CssSelect.php
@@ -104,7 +104,7 @@ class CssSelect
     /**
      * Select elements using css $selector.
      *
-     * When $asArray is true:
+     * When $asDomList is false (default):
      * matching elements will be return as an associative array containing
      *      name : element name
      *      attributes : attributes array


### PR DESCRIPTION
Probably an older version used a parameter named `$asArray` (defaulting to `true`), whereas the current  version uses `$asDomList` (defaulting to `false`).

The external effect is the same, but the documentation ended up being out of sync.
